### PR TITLE
Refactor prompt builders to use tokenizer chat templates

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,4 +1,3 @@
-from src.prompt import apply_prompt_template
 from sklearn.model_selection import train_test_split
 import pandas as pd
 from src.config import Config
@@ -8,7 +7,6 @@ from src.peft_model import get_trainer
 
 def main():
     df = pd.read_csv("data/vihallu-train.csv")
-    df[Config.fine_tune_prompt_column] = df.apply(apply_prompt_template, axis=1)
 
     train_df, val_df = train_test_split(df, test_size=Config.valid_size, random_state=Config.random_state, stratify=df[Config.label_column])
     train_df = train_df.reset_index(drop=True)

--- a/src/inference.py
+++ b/src/inference.py
@@ -1,0 +1,12 @@
+from src.prompt import create_inference_prompt
+from src.peft_model import model, tokenizer
+
+
+def generate(sample, max_new_tokens: int = 256):
+    """Run inference on a single sample using the trained model."""
+
+    prompt = create_inference_prompt(sample, tokenizer)
+    inputs = tokenizer(prompt, return_tensors="pt").to(model.device)
+    outputs = model.generate(**inputs, max_new_tokens=max_new_tokens)
+    return tokenizer.decode(outputs[0], skip_special_tokens=True)
+

--- a/src/prompt.py
+++ b/src/prompt.py
@@ -1,22 +1,12 @@
-def create_finetuning_prompt(sample):
-    """
-    Tạo prompt hoàn chỉnh cho một mẫu dữ liệu theo template của VinaLLaMA và cấu trúc CoT.
-    
-    Args:
-        sample (dict): Một dictionary chứa các key 'context', 'prompt', 'response', 'label'.
-    
-    Returns:
-        str: Chuỗi prompt đã được định dạng để fine-tune.
-    """
-    
-    # 1. Phần System: Chỉ dẫn chung, không đổi cho mọi sample
+def create_finetuning_prompt(sample, tokenizer):
+    """Build a full fine-tuning prompt using the tokenizer's chat template."""
+
     system_message = (
         "Bạn là một chuyên gia kiểm định thông tin, cực kỳ cẩn thận và chính xác. "
         "Nhiệm vụ của bạn là phân tích và phát hiện ảo giác (hallucination) trong văn bản do AI tạo ra. "
         "Bạn phải thực hiện phân tích theo từng bước logic và đưa ra nhãn cuối cùng là một trong ba loại: 'no', 'intrinsic', hoặc 'extrinsic'."
     )
 
-    # 2. Phần User: Chứa dữ liệu của một sample cụ thể
     user_message = (
         f"Hãy thực hiện phân tích chi tiết cho dữ liệu sau đây.\n\n"
         f"Ngữ cảnh:\n{sample['context']}\n\n"
@@ -24,10 +14,7 @@ def create_finetuning_prompt(sample):
         f"Phản hồi cần đánh giá:\n{sample['response']}"
     )
 
-    # 3. Phần Assistant: Đây là "đáp án mẫu" mà mô hình sẽ học theo
-    # Chúng ta sẽ tạo một phần phân tích logic dựa trên nhãn (label) có sẵn
     label = sample['label']
-    analysis = ""
     if label == 'no':
         analysis = (
             "Phân tích từng bước:\n"
@@ -42,31 +29,55 @@ def create_finetuning_prompt(sample):
             "2. Phân tích thông tin ngoài (Extrinsic): Không xét đến vì đã phát hiện mâu thuẫn.\n"
             "3. Kết luận: Do có sự mâu thuẫn trực tiếp với Ngữ cảnh, nhãn phù hợp là 'intrinsic'."
         )
-    elif label == 'extrinsic':
+    else:  # 'extrinsic'
         analysis = (
             "Phân tích từng bước:\n"
             "1. Phân tích mâu thuẫn (Intrinsic): Phản hồi không chứa thông tin nào mâu thuẫn trực tiếp với Ngữ cảnh.\n"
             "2. Phân tích thông tin ngoài (Extrinsic): Phản hồi đã bổ sung thêm các chi tiết, sự kiện hoặc bối cảnh không thể tìm thấy hoặc suy luận từ Ngữ cảnh.\n"
             "3. Kết luận: Vì phản hồi đã thêm thông tin không có căn cứ từ Ngữ cảnh, nhãn phù hợp là 'extrinsic'."
         )
-    
+
     assistant_message = f"{analysis}\n\nNhãn cuối cùng:\n{label}"
 
-    # 4. Ghép tất cả lại thành một chuỗi duy nhất
-    final_prompt = (
-        f"<|im_start|>system\n{system_message}<|im_end|>\n"
-        f"<|im_start|>user\n{user_message}<|im_end|>\n"
-        f"<|im_start|>assistant\n{assistant_message}"
-    )
-    
-    return final_prompt
+    messages = [
+        {"role": "system", "content": system_message},
+        {"role": "user", "content": user_message},
+        {"role": "assistant", "content": assistant_message},
+    ]
 
-def apply_prompt_template(row):
-    # Hàm create_finetuning_prompt nhận vào một dictionary
+    return tokenizer.apply_chat_template(messages, tokenize=False, add_generation_prompt=False)
+
+
+def create_inference_prompt(sample, tokenizer):
+    """Build a prompt for inference using the tokenizer's chat template."""
+
+    system_message = (
+        "Bạn là một chuyên gia kiểm định thông tin, cực kỳ cẩn thận và chính xác. "
+        "Nhiệm vụ của bạn là phân tích và phát hiện ảo giác (hallucination) trong văn bản do AI tạo ra. "
+        "Bạn phải thực hiện phân tích theo từng bước logic và đưa ra nhãn cuối cùng là một trong ba loại: 'no', 'intrinsic', hoặc 'extrinsic'."
+    )
+
+    user_message = (
+        f"Hãy thực hiện phân tích chi tiết cho dữ liệu sau đây.\n\n"
+        f"Ngữ cảnh:\n{sample['context']}\n\n"
+        f"Câu hỏi:\n{sample['prompt']}\n\n"
+        f"Phản hồi cần đánh giá:\n{sample['response']}"
+    )
+
+    messages = [
+        {"role": "system", "content": system_message},
+        {"role": "user", "content": user_message},
+    ]
+
+    return tokenizer.apply_chat_template(messages, tokenize=False, add_generation_prompt=True)
+
+
+def apply_prompt_template(row, tokenizer):
     sample = {
         'context': row['context'],
         'prompt': row['prompt'],
-        'response': row['response'], # Bạn cần có cột 'response' trong df
-        'label': row['label']
+        'response': row['response'],
+        'label': row['label'],
     }
-    return create_finetuning_prompt(sample)
+    return create_finetuning_prompt(sample, tokenizer)
+


### PR DESCRIPTION
## Summary
- Build fine-tuning prompts as message lists and render them with `tokenizer.apply_chat_template`
- Add `create_inference_prompt` and new inference helper using tokenizer-based templates
- Format training examples on-the-fly in `peft_model.formatting_func`

## Testing
- `python -m py_compile src/*.py main.py`

------
https://chatgpt.com/codex/tasks/task_e_68be8a8d890483218da0dabfbaed2acb